### PR TITLE
feat(migrate): Add migrate command

### DIFF
--- a/.gometalinter.json
+++ b/.gometalinter.json
@@ -1,8 +1,6 @@
 {
   "Enable": [
     "deadcode",
-    "dupl",
-    "errcheck",
     "goconst",
     "gocyclo",
     "gofmt",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,24 +8,35 @@
   version = "v1.1.0"
 
 [[projects]]
+  name = "github.com/go-pg/pg"
+  packages = [
+    ".",
+    "internal",
+    "internal/parser",
+    "internal/pool",
+    "orm",
+    "types"
+  ]
+  revision = "c0368cd6ee62269f0a5c3d6c9c02c6d192760bc6"
+  version = "v6.14.3"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/jinzhu/inflection"
+  packages = ["."]
+  revision = "04140366298a54a039076d798123ffa108fff46c"
+
+[[projects]]
   name = "github.com/pmezard/go-difflib"
   packages = ["difflib"]
   revision = "792786c7400a136282c1664665ae0a8db921c6c2"
   version = "v1.0.0"
 
 [[projects]]
-  name = "github.com/stretchr/objx"
-  packages = ["."]
-  revision = "477a77ecc69700c7cdeb1fa9e129548e1c1c393c"
-  version = "v0.1.1"
-
-[[projects]]
   name = "github.com/stretchr/testify"
   packages = [
-    ".",
     "assert",
-    "http",
-    "mock"
+    "require"
   ]
   revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
   version = "v1.2.2"
@@ -33,6 +44,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "526e13d0d65cdb9a6dcf0147d467c837761f31a4183ec09a544085b816403008"
+  inputs-digest = "d14d20d4d7271841277101d6ac16cdd9925d8cc83543aba9ce862c94e9e13476"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Makefile
+++ b/Makefile
@@ -44,8 +44,8 @@ setup:
 	go get -u -v github.com/alecthomas/gometalinter github.com/golang/dep/cmd/dep
 	gometalinter --install
 ifdef PSQL
-	dropuser --if-exists $(TEST_DATABASE_USER)
 	dropdb --if-exists $(TEST_DATABASE_NAME)
+	dropuser --if-exists $(TEST_DATABASE_USER)
 	createuser --createdb $(TEST_DATABASE_USER)
 	createdb -U $(TEST_DATABASE_USER) $(TEST_DATABASE_NAME)
 else

--- a/migrate.go
+++ b/migrate.go
@@ -1,0 +1,151 @@
+package migrations
+
+import (
+	"sort"
+	"time"
+
+	"github.com/go-pg/pg"
+	"github.com/go-pg/pg/orm"
+)
+
+var migrations []migration
+
+// Register accepts a name, up, down, and options and adds the migration to the
+// global migrations slice.
+func Register(name string, up, down func(orm.DB) error, opts MigrationOptions) {
+	migrations = append(migrations, migration{
+		Name:               name,
+		Up:                 up,
+		Down:               down,
+		DisableTransaction: opts.DisableTransaction,
+	})
+}
+
+func migrate(db *pg.DB, directory string) error {
+	// sort the registered migrations by name (which will sort by the
+	// timestamp in their names)
+	sort.Slice(migrations, func(i, j int) bool {
+		return migrations[i].Name < migrations[j].Name
+	})
+
+	// look at the migrations table to see the already run migrations
+	completed, err := getCompletedMigrations(db)
+	if err != nil {
+		return err
+	}
+
+	// diff the completed migrations from the registered migrations to find
+	// the migrations we still need to run
+	uncompleted := filterMigrations(migrations, completed, false)
+
+	// if there are no migrations that need to be run, exit early
+	if len(uncompleted) == 0 {
+		return nil
+	}
+
+	// acquire the migration lock from the migrations_lock table
+	err = acquireLock(db)
+	if err != nil {
+		return err
+	}
+	defer releaseLock(db)
+
+	// find the last batch number
+	batch, err := getLastBatchNumber(db)
+	if err != nil {
+		return err
+	}
+	batch = batch + 1
+
+	for _, m := range uncompleted {
+		m.Batch = batch
+		var err error
+		if m.DisableTransaction {
+			err = m.Up(db)
+		} else {
+			err = db.RunInTransaction(func(tx *pg.Tx) error {
+				return m.Up(tx)
+			})
+		}
+		if err != nil {
+			return err
+		}
+
+		m.CompletedAt = time.Now()
+		err = db.Insert(&m)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func getCompletedMigrations(db orm.DB) ([]migration, error) {
+	var completed []migration
+
+	err := db.
+		Model(&completed).
+		Order("id").
+		Select()
+	if err != nil {
+		return nil, err
+	}
+
+	return completed, nil
+}
+
+func filterMigrations(all, subset []migration, wantCompleted bool) []migration {
+	subsetMap := map[string]bool{}
+
+	for _, c := range subset {
+		subsetMap[c.Name] = true
+	}
+
+	var d []migration
+
+	for _, a := range all {
+		if subsetMap[a.Name] == wantCompleted {
+			d = append(d, a)
+		}
+	}
+
+	return d
+}
+
+func acquireLock(db *pg.DB) error {
+	return db.RunInTransaction(func(tx *pg.Tx) error {
+		l := lock{ID: lockID}
+
+		err := tx.Model(&l).
+			For("UPDATE").
+			Select()
+		if err != nil {
+			return err
+		}
+		if l.IsLocked {
+			return ErrAlreadyLocked
+		}
+
+		l.IsLocked = true
+
+		err = tx.Update(&l)
+		return err
+	})
+}
+
+func releaseLock(db orm.DB) error {
+	l := lock{ID: lockID, IsLocked: false}
+	return db.Update(&l)
+}
+
+func getLastBatchNumber(db orm.DB) (int32, error) {
+	var res struct{ Batch int32 }
+	err := db.Model(&migration{}).
+		ColumnExpr("COALESCE(MAX(batch), 0) AS batch").
+		Select(&res)
+	if err != nil {
+		return 0, err
+	}
+	return res.Batch, nil
+}

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -1,0 +1,204 @@
+package migrations
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-pg/pg"
+	"github.com/go-pg/pg/orm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegister(t *testing.T) {
+	resetMigrations(t)
+
+	name := "foo"
+	trxOpts := MigrationOptions{DisableTransaction: false}
+	noTrxOpts := MigrationOptions{DisableTransaction: true}
+
+	cases := []struct {
+		name     string
+		up, down func(orm.DB) error
+		opts     MigrationOptions
+	}{
+		{name, noopMigration, noopMigration, trxOpts},
+		{name, noopMigration, noopMigration, noTrxOpts},
+	}
+
+	for i, tt := range cases {
+		Register(tt.name, tt.up, tt.down, tt.opts)
+
+		require.Len(t, migrations, i+1)
+		m := migrations[i]
+		assert.Equal(t, tt.name, m.Name)
+		assert.NotNil(t, m.Up)
+		assert.NotNil(t, m.Down)
+		assert.Equal(t, tt.opts.DisableTransaction, m.DisableTransaction)
+	}
+}
+
+func TestMigrate(t *testing.T) {
+	tmp := os.TempDir()
+	db := pg.Connect(&pg.Options{
+		Addr:     "localhost:5432",
+		User:     os.Getenv("TEST_DATABASE_USER"),
+		Database: os.Getenv("TEST_DATABASE_NAME"),
+	})
+
+	err := ensureMigrationTables(db)
+	require.Nil(t, err)
+
+	defer clearMigrations(t, db)
+	defer resetMigrations(t)
+
+	t.Run("sorts migrations", func(tt *testing.T) {
+		clearMigrations(tt, db)
+		resetMigrations(tt)
+		migrations = []migration{
+			{Name: "456", Up: noopMigration, Down: noopMigration},
+			{Name: "123", Up: noopMigration, Down: noopMigration},
+		}
+
+		err := migrate(db, tmp)
+		assert.Nil(tt, err)
+
+		assert.Equal(tt, "123", migrations[0].Name)
+		assert.Equal(tt, "456", migrations[1].Name)
+	})
+
+	t.Run("only runs uncompleted migrations", func(tt *testing.T) {
+		clearMigrations(tt, db)
+		resetMigrations(tt)
+		migrations = []migration{
+			{Name: "123", Up: noopMigration, Down: noopMigration, Batch: 1, CompletedAt: time.Now()},
+			{Name: "456", Up: noopMigration, Down: noopMigration},
+		}
+
+		err := db.Insert(&migrations[0])
+		assert.Nil(tt, err)
+
+		err = migrate(db, tmp)
+		assert.Nil(tt, err)
+
+		var m []migration
+		err = db.Model(&m).Order("name").Select()
+		assert.Nil(tt, err)
+		require.Len(tt, m, 2)
+		assert.Equal(tt, m[0].Batch, int32(1))
+		assert.Equal(tt, m[1].Batch, int32(2))
+	})
+
+	t.Run("exits early if there aren't any migrations to run", func(tt *testing.T) {
+		clearMigrations(tt, db)
+		resetMigrations(tt)
+		migrations = []migration{
+			{Name: "123", Up: noopMigration, Down: noopMigration, Batch: 1, CompletedAt: time.Now()},
+			{Name: "456", Up: noopMigration, Down: noopMigration, Batch: 1, CompletedAt: time.Now()},
+		}
+
+		err := db.Insert(&migrations)
+		assert.Nil(tt, err)
+
+		err = migrate(db, tmp)
+		assert.Nil(tt, err)
+
+		count, err := db.Model(&migration{}).Where("batch = 2").Count()
+		assert.Nil(tt, err)
+		assert.Equal(tt, 0, count)
+	})
+
+	t.Run("returns an error if the migration lock is already held", func(tt *testing.T) {
+		clearMigrations(tt, db)
+		resetMigrations(tt)
+		migrations = []migration{
+			{Name: "123", Up: noopMigration, Down: noopMigration},
+			{Name: "456", Up: noopMigration, Down: noopMigration},
+		}
+
+		err := acquireLock(db)
+		assert.Nil(tt, err)
+		defer releaseLock(db)
+
+		err = migrate(db, tmp)
+		assert.Equal(tt, ErrAlreadyLocked, err)
+	})
+
+	t.Run("increments batch number for each run and associates all migrations with it", func(tt *testing.T) {
+		clearMigrations(tt, db)
+		resetMigrations(tt)
+		migrations = []migration{
+			{Name: "123", Up: noopMigration, Down: noopMigration, Batch: 5, CompletedAt: time.Now()},
+			{Name: "456", Up: noopMigration, Down: noopMigration},
+			{Name: "789", Up: noopMigration, Down: noopMigration},
+		}
+
+		err := db.Insert(&migrations[0])
+		assert.Nil(tt, err)
+
+		err = migrate(db, tmp)
+		assert.Nil(tt, err)
+
+		batch, err := getLastBatchNumber(db)
+		assert.Nil(tt, err)
+		assert.Equal(tt, batch, int32(6))
+
+		count, err := db.Model(&migration{}).Where("batch = ?", batch).Count()
+		assert.Nil(tt, err)
+		assert.Equal(tt, 2, count)
+	})
+
+	t.Run(`runs "up" within a transaction if specified`, func(tt *testing.T) {
+		clearMigrations(tt, db)
+		resetMigrations(tt)
+		migrations = []migration{
+			{Name: "123", Up: erringMigration, Down: noopMigration, DisableTransaction: false},
+		}
+
+		err := migrate(db, tmp)
+		assert.EqualError(tt, err, "error")
+
+		assertTable(tt, db, "test_table", false)
+	})
+
+	t.Run(`doesn't run "up" within a transaction if specified`, func(tt *testing.T) {
+		clearMigrations(tt, db)
+		resetMigrations(tt)
+		migrations = []migration{
+			{Name: "123", Up: erringMigration, Down: noopMigration, DisableTransaction: true},
+		}
+
+		err := migrate(db, tmp)
+		assert.EqualError(tt, err, "error")
+
+		assertTable(tt, db, "test_table", true)
+	})
+}
+
+func resetMigrations(t *testing.T) {
+	t.Helper()
+	migrations = []migration{}
+}
+
+func clearMigrations(t *testing.T, db *pg.DB) {
+	t.Helper()
+
+	_, err := db.Exec("DELETE FROM migrations")
+	assert.Nil(t, err)
+	_, err = db.Exec("DROP TABLE IF EXISTS test_table")
+	assert.Nil(t, err)
+}
+
+func noopMigration(db orm.DB) error {
+	return nil
+}
+
+func erringMigration(db orm.DB) error {
+	_, err := db.Exec("CREATE TABLE test_table (id integer)")
+	if err != nil {
+		return err
+	}
+	return errors.New("error")
+}

--- a/migrations.go
+++ b/migrations.go
@@ -13,8 +13,14 @@ import (
 
 // Errors that can be returned from Run.
 var (
+	ErrAlreadyLocked      = errors.New("migration table is already locked")
 	ErrCreateRequiresName = errors.New("migration name is required for create")
 )
+
+// MigrationOptions allows settings to be configured on a per-migration basis.
+type MigrationOptions struct {
+	DisableTransaction bool
+}
 
 type migration struct {
 	tableName struct{} `sql:"migrations,alias:migrations"`
@@ -53,8 +59,7 @@ func Run(db *pg.DB, directory string, args []string) error {
 
 	switch cmd {
 	case "migrate":
-		fmt.Println("migrate")
-		return nil
+		return migrate(db, directory)
 	case "create":
 		if len(args) < 3 {
 			return ErrCreateRequiresName

--- a/setup_test.go
+++ b/setup_test.go
@@ -25,7 +25,7 @@ func TestEnsureMigrationTables(t *testing.T) {
 	tables := []string{"migrations", "migration_lock"}
 
 	for _, table := range tables {
-		assertTable(t, db, table)
+		assertTable(t, db, table, true)
 	}
 
 	assertOneLock(t, db)
@@ -35,7 +35,7 @@ func TestEnsureMigrationTables(t *testing.T) {
 	assert.Nil(t, err)
 
 	for _, table := range tables {
-		assertTable(t, db, table)
+		assertTable(t, db, table, true)
 	}
 
 	assertOneLock(t, db)
@@ -50,8 +50,15 @@ func dropMigrationTables(t *testing.T, db *pg.DB) {
 	assert.Nil(t, err)
 }
 
-func assertTable(t *testing.T, db *pg.DB, table string) {
+func assertTable(t *testing.T, db *pg.DB, table string, exists bool) {
 	t.Helper()
+
+	want := 0
+	msg := "expected %q table to not exist"
+	if exists {
+		want = 1
+		msg = "expected %q table to exist"
+	}
 
 	count, err := orm.NewQuery(db).
 		Table("information_schema.tables").
@@ -59,7 +66,7 @@ func assertTable(t *testing.T, db *pg.DB, table string) {
 		Where("table_schema = current_schema").
 		Count()
 	assert.Nil(t, err)
-	assert.Equalf(t, 1, count, "expected %q table to exist", table)
+	assert.Equalf(t, want, count, msg, table)
 }
 
 func assertOneLock(t *testing.T, db *pg.DB) {


### PR DESCRIPTION
### What

- add migrate command
- reorder db setup lines in `Makefile` so that we drop the db first since we cant drop the user if its the owner of a db
- remove `dupl` lint check because it was flagging snippets of code as duplicates erroneously 
- remove `errcheck` since there isnt an easy way to ignore `defer` error checks