### PR TITLE
docs(changelog): Add chglog support

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,0 +1,30 @@
+{{ range .Versions }}
+<a name="{{ .Tag.Name }}"></a>
+## {{ if .Tag.Previous }}[{{ .Tag.Name }}]({{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}){{ else }}{{ .Tag.Name }}{{ end }} ({{ datetime "2006-01-02" .Tag.Date }})
+
+{{ range .CommitGroups -}}
+### {{ .Title }}
+
+{{ range .Commits -}}
+* {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+
+{{- if .RevertCommits -}}
+### Reverts
+
+{{ range .RevertCommits -}}
+* {{ .Revert.Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .NoteGroups -}}
+{{ range .NoteGroups -}}
+### {{ .Title }}
+
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -1,0 +1,22 @@
+style: github
+template: CHANGELOG.tpl.md
+info:
+  title: CHANGELOG
+  repository_url: https://github.com/robinjoseph08/go-pg-migrations
+options:
+  commit_groups:
+    title_maps:
+      docs: Documentation
+      feat: Features
+      fix: Bug Fixes
+      perf: Performance Improvements
+      refactor: Code Refactoring
+  header:
+    pattern: "^(\\w*)(?:\\(([\\w\\$\\.\\-\\*\\s]*)\\))?\\:\\s(.*)$"
+    pattern_maps:
+      - Type
+      - Scope
+      - Subject
+  notes:
+    keywords:
+      - BREAKING CHANGE

--- a/Makefile
+++ b/Makefile
@@ -38,10 +38,22 @@ lint:
 	@echo "---> Linting..."
 	gometalinter --vendor --tests $(DIRS)
 
+.PHONY: release
+release:
+	@echo "---> Creating new release"
+ifndef tag
+	$(error tag must be specified)
+endif
+	git-chglog --output CHANGELOG.md --next-tag $(tag)
+	git add CHANGELOG.md
+	git commit -m $(tag)
+	git tag $(tag)
+	git push origin master --tags
+
 .PHONY: setup
 setup:
 	@echo "--> Setting up"
-	go get -u -v github.com/alecthomas/gometalinter github.com/golang/dep/cmd/dep
+	go get -u -v github.com/alecthomas/gometalinter github.com/golang/dep/cmd/dep github.com/git-chglog/git-chglog/cmd/git-chglog
 	gometalinter --install
 ifdef PSQL
 	dropdb --if-exists $(TEST_DATABASE_NAME)


### PR DESCRIPTION
### What

- add `make release` that does the following:
  - updates the changelog
  - commits it
  - creates new git tag
  - pushes commit and tag to github