### PR TITLE
feat(errors): Add migration name for migrate/rollback errors

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -15,6 +15,7 @@ func main() {
 		Addr:     "localhost:5432",
 		User:     "test_user",
 		Database: "test",
+		Password: "",
 	})
 
 	err := migrations.Run(db, directory, os.Args)

--- a/migrate.go
+++ b/migrate.go
@@ -72,13 +72,13 @@ func migrate(db *pg.DB, directory string) error {
 			})
 		}
 		if err != nil {
-			return err
+			return fmt.Errorf("%s: %s", m.Name, err)
 		}
 
 		m.CompletedAt = time.Now()
 		err = db.Insert(&m)
 		if err != nil {
-			return err
+			return fmt.Errorf("%s: %s", m.Name, err)
 		}
 		fmt.Printf("Finished running %q\n", m.Name)
 	}

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -158,7 +158,7 @@ func TestMigrate(t *testing.T) {
 		}
 
 		err := migrate(db, tmp)
-		assert.EqualError(tt, err, "error")
+		assert.EqualError(tt, err, "123: error")
 
 		assertTable(tt, db, "test_table", false)
 	})
@@ -171,7 +171,7 @@ func TestMigrate(t *testing.T) {
 		}
 
 		err := migrate(db, tmp)
-		assert.EqualError(tt, err, "error")
+		assert.EqualError(tt, err, "123: error")
 
 		assertTable(tt, db, "test_table", true)
 	})

--- a/rollback.go
+++ b/rollback.go
@@ -52,12 +52,12 @@ func rollback(db *pg.DB, directory string) error {
 			})
 		}
 		if err != nil {
-			return err
+			return fmt.Errorf("%s: %s", m.Name, err)
 		}
 
 		_, err = db.Model(&m).Where("name = ?", m.Name).Delete()
 		if err != nil {
-			return err
+			return fmt.Errorf("%s: %s", m.Name, err)
 		}
 		fmt.Printf("Finished rolling back %q\n", m.Name)
 	}

--- a/rollback_test.go
+++ b/rollback_test.go
@@ -108,7 +108,7 @@ func TestRollback(t *testing.T) {
 		assert.Nil(tt, err)
 
 		err = rollback(db, tmp)
-		assert.EqualError(tt, err, "error")
+		assert.EqualError(tt, err, "123: error")
 
 		assertTable(tt, db, "test_table", false)
 	})
@@ -124,7 +124,7 @@ func TestRollback(t *testing.T) {
 		assert.Nil(tt, err)
 
 		err = rollback(db, tmp)
-		assert.EqualError(tt, err, "error")
+		assert.EqualError(tt, err, "123: error")
 
 		assertTable(tt, db, "test_table", true)
 	})


### PR DESCRIPTION
if an error occurs during a migration or a rollback, the error is annotated with the name of the migration that caused the error. this makes it easier to debug the source of the error. for example:

```
$ go run example/*.go migrate
Running batch 1 with 1 migration(s)...
2018/08/23 19:36:52 20180812001528_create_users_table: ERROR #42601 syntax error at or near ")" (addr="[::1]:5432")
exit status 1
```