### PR TITLE
Update migration template to refer to /v2.

### DIFF
--- a/create.go
+++ b/create.go
@@ -13,7 +13,7 @@ var template = `package main
 
 import (
 	"github.com/go-pg/pg/v9/orm"
-	migrations "github.com/robinjoseph08/go-pg-migrations"
+	migrations "github.com/robinjoseph08/go-pg-migrations/v2"
 )
 
 func init() {


### PR DESCRIPTION
This fixes the issue reported in #17.