### PR TITLE
chore(directory): don't unnecessarily pass in directory

### DIFF
--- a/migrate.go
+++ b/migrate.go
@@ -22,7 +22,7 @@ func Register(name string, up, down func(orm.DB) error, opts MigrationOptions) {
 	})
 }
 
-func migrate(db *pg.DB, directory string) error {
+func migrate(db *pg.DB) error {
 	// sort the registered migrations by name (which will sort by the
 	// timestamp in their names)
 	sort.Slice(migrations, func(i, j int) bool {

--- a/migrate_test.go
+++ b/migrate_test.go
@@ -41,7 +41,6 @@ func TestRegister(t *testing.T) {
 }
 
 func TestMigrate(t *testing.T) {
-	tmp := os.TempDir()
 	db := pg.Connect(&pg.Options{
 		Addr:     "localhost:5432",
 		User:     os.Getenv("TEST_DATABASE_USER"),
@@ -62,7 +61,7 @@ func TestMigrate(t *testing.T) {
 			{Name: "123", Up: noopMigration, Down: noopMigration},
 		}
 
-		err := migrate(db, tmp)
+		err := migrate(db)
 		assert.Nil(tt, err)
 
 		assert.Equal(tt, "123", migrations[0].Name)
@@ -80,7 +79,7 @@ func TestMigrate(t *testing.T) {
 		err := db.Insert(&migrations[0])
 		assert.Nil(tt, err)
 
-		err = migrate(db, tmp)
+		err = migrate(db)
 		assert.Nil(tt, err)
 
 		var m []migration
@@ -102,7 +101,7 @@ func TestMigrate(t *testing.T) {
 		err := db.Insert(&migrations)
 		assert.Nil(tt, err)
 
-		err = migrate(db, tmp)
+		err = migrate(db)
 		assert.Nil(tt, err)
 
 		count, err := db.Model(&migration{}).Where("batch = 2").Count()
@@ -122,7 +121,7 @@ func TestMigrate(t *testing.T) {
 		assert.Nil(tt, err)
 		defer releaseLock(db)
 
-		err = migrate(db, tmp)
+		err = migrate(db)
 		assert.Equal(tt, ErrAlreadyLocked, err)
 	})
 
@@ -138,7 +137,7 @@ func TestMigrate(t *testing.T) {
 		err := db.Insert(&migrations[0])
 		assert.Nil(tt, err)
 
-		err = migrate(db, tmp)
+		err = migrate(db)
 		assert.Nil(tt, err)
 
 		batch, err := getLastBatchNumber(db)
@@ -157,7 +156,7 @@ func TestMigrate(t *testing.T) {
 			{Name: "123", Up: erringMigration, Down: noopMigration, DisableTransaction: false},
 		}
 
-		err := migrate(db, tmp)
+		err := migrate(db)
 		assert.EqualError(tt, err, "123: error")
 
 		assertTable(tt, db, "test_table", false)
@@ -170,7 +169,7 @@ func TestMigrate(t *testing.T) {
 			{Name: "123", Up: erringMigration, Down: noopMigration, DisableTransaction: true},
 		}
 
-		err := migrate(db, tmp)
+		err := migrate(db)
 		assert.EqualError(tt, err, "123: error")
 
 		assertTable(tt, db, "test_table", true)

--- a/migrations.go
+++ b/migrations.go
@@ -58,7 +58,7 @@ func Run(db *pg.DB, directory string, args []string) error {
 			return err
 		}
 
-		return migrate(db, directory)
+		return migrate(db)
 	case "create":
 		if len(args) < 3 {
 			return ErrCreateRequiresName
@@ -71,7 +71,7 @@ func Run(db *pg.DB, directory string, args []string) error {
 			return err
 		}
 
-		return rollback(db, directory)
+		return rollback(db)
 	default:
 		help(directory)
 		return nil

--- a/rollback.go
+++ b/rollback.go
@@ -7,7 +7,7 @@ import (
 	"github.com/go-pg/pg/v9"
 )
 
-func rollback(db *pg.DB, directory string) error {
+func rollback(db *pg.DB) error {
 	// sort the registered migrations by name (which will sort by the
 	// timestamp in their names)
 	sort.Slice(migrations, func(i, j int) bool {

--- a/rollback_test.go
+++ b/rollback_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestRollback(t *testing.T) {
-	tmp := os.TempDir()
 	db := pg.Connect(&pg.Options{
 		Addr:     "localhost:5432",
 		User:     os.Getenv("TEST_DATABASE_USER"),
@@ -32,7 +31,7 @@ func TestRollback(t *testing.T) {
 			{Name: "456", Up: noopMigration, Down: noopMigration},
 		}
 
-		err := rollback(db, tmp)
+		err := rollback(db)
 		assert.Nil(tt, err)
 
 		assert.Equal(tt, "456", migrations[0].Name)
@@ -51,7 +50,7 @@ func TestRollback(t *testing.T) {
 		assert.Nil(tt, err)
 		defer releaseLock(db)
 
-		err = rollback(db, tmp)
+		err = rollback(db)
 		assert.Equal(tt, ErrAlreadyLocked, err)
 	})
 
@@ -63,7 +62,7 @@ func TestRollback(t *testing.T) {
 			{Name: "456", Up: noopMigration, Down: noopMigration},
 		}
 
-		err := rollback(db, tmp)
+		err := rollback(db)
 		assert.Nil(tt, err)
 
 		count, err := db.Model(&migration{}).Count()
@@ -85,7 +84,7 @@ func TestRollback(t *testing.T) {
 		err := db.Insert(&m)
 		assert.Nil(tt, err)
 
-		err = rollback(db, tmp)
+		err = rollback(db)
 		assert.Nil(tt, err)
 
 		batch, err := getLastBatchNumber(db)
@@ -107,7 +106,7 @@ func TestRollback(t *testing.T) {
 		err := db.Insert(&migrations)
 		assert.Nil(tt, err)
 
-		err = rollback(db, tmp)
+		err = rollback(db)
 		assert.EqualError(tt, err, "123: error")
 
 		assertTable(tt, db, "test_table", false)
@@ -123,7 +122,7 @@ func TestRollback(t *testing.T) {
 		err := db.Insert(&migrations)
 		assert.Nil(tt, err)
 
-		err = rollback(db, tmp)
+		err = rollback(db)
 		assert.EqualError(tt, err, "123: error")
 
 		assertTable(tt, db, "test_table", true)


### PR DESCRIPTION
### what

fixes #24 

since `directory` wasn't used in `migrate` or `rollback`, it was just causing confusion, so it's better to just remove it