### PR TITLE
adds a 'status' command that checks for pending migrations.

### DIFF
--- a/help.go
+++ b/help.go
@@ -9,6 +9,7 @@ Commands:
   create   - create a new migration in %s with the provided name
   migrate  - run any migrations that haven't been run yet
   rollback - roll back the previous run batch of migrations
+  status   - check if there are pending migrations
   help     - print this help text
 
 Examples:

--- a/migrations.go
+++ b/migrations.go
@@ -72,6 +72,13 @@ func Run(db *pg.DB, directory string, args []string) error {
 		}
 
 		return rollback(db)
+	case "status":
+		err := ensureMigrationTables(db)
+		if err != nil {
+			return err
+		}
+
+		return migrationStatus(db)
 	default:
 		help(directory)
 		return nil

--- a/status.go
+++ b/status.go
@@ -1,0 +1,34 @@
+package migrations
+
+import (
+	"fmt"
+
+	"github.com/go-pg/pg/v10"
+)
+
+func migrationStatus(db *pg.DB) error {
+	uncompleted, err := getUncompletedMigrations(db)
+	if err != nil {
+		return nil
+	}
+
+	if len(uncompleted) == 0 {
+		fmt.Println("Migrations already up to date")
+		return nil
+	}
+
+	return ErrPendingMigrations{len(uncompleted)}
+}
+
+// ErrPendingMigrations is returned by the 'status' command when there is at
+// least one pending migration
+type ErrPendingMigrations struct {
+	N int
+}
+
+func (p ErrPendingMigrations) Error() string {
+	if p.N == 1 {
+		return "1 migration is pending"
+	}
+	return fmt.Sprintf("%d migrations are pending", p.N)
+}

--- a/status_test.go
+++ b/status_test.go
@@ -1,0 +1,58 @@
+package migrations
+
+import (
+	"os"
+	"testing"
+
+	"github.com/go-pg/pg/v10"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigrationStatus(t *testing.T) {
+	db := pg.Connect(&pg.Options{
+		Addr:     "localhost:5432",
+		User:     os.Getenv("TEST_DATABASE_USER"),
+		Database: os.Getenv("TEST_DATABASE_NAME"),
+	})
+
+	err := ensureMigrationTables(db)
+	require.Nil(t, err)
+
+	defer clearMigrations(t, db)
+	defer resetMigrations(t)
+
+	t.Run("Returns nil if migrations are up to date", func(tt *testing.T) {
+		clearMigrations(tt, db)
+		resetMigrations(tt)
+
+		migrations = []migration{
+			{Name: "123", Up: noopMigration, Down: noopMigration},
+		}
+
+		_, err := db.Model(&migrations[0]).Insert()
+		assert.Nil(tt, err)
+
+		pendingErr := migrationStatus(db)
+		assert.Nil(tt, pendingErr)
+	})
+
+	t.Run("Returns an error if migrations are not up to date", func(tt *testing.T) {
+		clearMigrations(tt, db)
+		resetMigrations(tt)
+
+		migrations = []migration{
+			{Name: "123", Up: noopMigration, Down: noopMigration},
+		}
+
+		pendingErr := migrationStatus(db)
+		assert.EqualError(tt, pendingErr, "1 migration is pending")
+
+		migrations = append(migrations, migration{
+			Name: "123", Up: noopMigration, Down: noopMigration,
+		})
+
+		pendingErr = migrationStatus(db)
+		assert.EqualError(tt, pendingErr, "2 migrations are pending")
+	})
+}


### PR DESCRIPTION
This adds a new command called 'status', that you run like this: `go run example/*.go status`. If there are no pending migrations, it will print a message indicating that migrations are up to date, and return nil. If there are pending migrations, it will return an error with the message indicating how many are pending. If things are set up as described in the example dir, this will also cause the program to exit with status 1.

This is useful in deployment, for example, in kubernetes, new pods can use this as a check to determine if they are ready to start receiving traffic.