### PR TITLE
feat(options): allow customizing the names of the migration tables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,11 @@ postgres:
 		-p 5432:5432 \
 		postgres:11
 
+.PHONY: psql
+psql:
+	@echo "---> Running psql"
+	psql -h localhost -p 5432 -U $(TEST_DATABASE_USER) -d $(TEST_DATABASE_NAME)
+
 .PHONY: release
 release:
 	@echo "---> Creating new release"

--- a/README.md
+++ b/README.md
@@ -32,8 +32,11 @@ files to be saved in (which will be the same directory of the main package, e.g.
 `example`), an instance of `*pg.DB`, and `os.Args`; and log any potential errors
 that could be returned.
 
-Once this has been set up, then you can use the `create`, `migrate`, `status`, `rollback`,
-`help` commands like so:
+You can also call `migrations.RunWithOptions` to configure the way that the
+migrations run (e.g. customize the name of the migration tables).
+
+Once this has been set up, then you can use the `create`, `migrate`, `status`,
+`rollback`, `help` commands like so:
 
 ```
 $ go run example/*.go create create_users_table

--- a/create.go
+++ b/create.go
@@ -33,7 +33,7 @@ func init() {
 }
 `
 
-func create(directory, name string) error {
+func (m *migrator) create(directory, name string) error {
 	version := time.Now().UTC().Format(timeFormat)
 	fullname := fmt.Sprintf("%s_%s", version, name)
 	filename := path.Join(directory, fullname+".go")

--- a/create_test.go
+++ b/create_test.go
@@ -15,8 +15,9 @@ func TestCreate(t *testing.T) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	tmp := os.TempDir()
 	name := fmt.Sprintf("create_test_migration_%d", r.Int())
+	m := newMigrator(nil, RunOptions{})
 
-	err := create(tmp, name)
+	err := m.create(tmp, name)
 	assert.Nil(t, err)
 
 	files, err := os.ReadDir(tmp)

--- a/migrate.go
+++ b/migrate.go
@@ -131,7 +131,7 @@ func (m *migrator) acquireLock() error {
 }
 
 func (m *migrator) releaseLock() error {
-	l := map[string]interface{}{"is_locked": true}
+	l := map[string]interface{}{"is_locked": false}
 	_, err := m.db.
 		Model(&l).
 		Table(m.opts.MigrationLockTableName).

--- a/migrations.go
+++ b/migrations.go
@@ -90,7 +90,7 @@ func RunWithOptions(db *pg.DB, directory string, args []string, opts RunOptions)
 			return err
 		}
 
-		return status(db, os.Stdout)
+		return m.status(os.Stdout)
 	default:
 		help(directory)
 		return nil

--- a/migrations_test.go
+++ b/migrations_test.go
@@ -42,41 +42,41 @@ func TestRunWithOptions(t *testing.T) {
 	db.AddQueryHook(logQueryHook{})
 
 	t.Run("default", func(tt *testing.T) {
-		dropMigrationTables(t, db)
+		dropMigrationTables(tt, db)
 
 		err := RunWithOptions(db, tmp, []string{"cmd", "migrate"}, RunOptions{})
-		assert.Nil(t, err)
-		assertTable(t, db, "migrations", true)
-		assertTable(t, db, "migration_lock", true)
-		assertTable(t, db, "custom_migrations", false)
-		assertTable(t, db, "custom_migration_lock", false)
+		assert.Nil(tt, err)
+		assertTable(tt, db, "migrations", true)
+		assertTable(tt, db, "migration_lock", true)
+		assertTable(tt, db, "custom_migrations", false)
+		assertTable(tt, db, "custom_migration_lock", false)
 	})
 
 	t.Run("custom tables - migrate", func(tt *testing.T) {
-		dropMigrationTables(t, db)
+		dropMigrationTables(tt, db)
 
 		err := RunWithOptions(db, tmp, []string{"cmd", "migrate"}, RunOptions{
 			MigrationsTableName:    "custom_migrations",
 			MigrationLockTableName: "custom_migration_lock",
 		})
-		assert.Nil(t, err)
-		assertTable(t, db, "custom_migrations", true)
-		assertTable(t, db, "custom_migration_lock", true)
-		assertTable(t, db, "migrations", false)
-		assertTable(t, db, "migration_lock", false)
+		assert.Nil(tt, err)
+		assertTable(tt, db, "custom_migrations", true)
+		assertTable(tt, db, "custom_migration_lock", true)
+		assertTable(tt, db, "migrations", false)
+		assertTable(tt, db, "migration_lock", false)
 	})
 
 	t.Run("custom tables - rollback", func(tt *testing.T) {
-		dropMigrationTables(t, db)
+		dropMigrationTables(tt, db)
 
 		err := RunWithOptions(db, tmp, []string{"cmd", "rollback"}, RunOptions{
 			MigrationsTableName:    "custom_migrations",
 			MigrationLockTableName: "custom_migration_lock",
 		})
-		assert.Nil(t, err)
-		assertTable(t, db, "custom_migrations", true)
-		assertTable(t, db, "custom_migration_lock", true)
-		assertTable(t, db, "migrations", false)
-		assertTable(t, db, "migration_lock", false)
+		assert.Nil(tt, err)
+		assertTable(tt, db, "custom_migrations", true)
+		assertTable(tt, db, "custom_migration_lock", true)
+		assertTable(tt, db, "migrations", false)
+		assertTable(tt, db, "migration_lock", false)
 	})
 }

--- a/migrator.go
+++ b/migrator.go
@@ -1,0 +1,30 @@
+package migrations
+
+import (
+	"strings"
+
+	"github.com/go-pg/pg/v10"
+)
+
+type migrator struct {
+	db   *pg.DB
+	opts RunOptions
+}
+
+func newMigrator(db *pg.DB, opts RunOptions) *migrator {
+	if opts.MigrationsTableName == "" {
+		opts.MigrationsTableName = "migrations"
+	}
+	if opts.MigrationLockTableName == "" {
+		opts.MigrationLockTableName = "migration_lock"
+	}
+
+	return &migrator{
+		db:   db,
+		opts: opts,
+	}
+}
+
+func escapeTableName(name string) string {
+	return strings.ReplaceAll(name, `"`, `""`)
+}

--- a/setup_test.go
+++ b/setup_test.go
@@ -15,11 +15,12 @@ func TestEnsureMigrationTables(t *testing.T) {
 		User:     os.Getenv("TEST_DATABASE_USER"),
 		Database: os.Getenv("TEST_DATABASE_NAME"),
 	})
+	m := newMigrator(db, RunOptions{})
 
 	// drop tables to start from a clean database
 	dropMigrationTables(t, db)
 
-	err := ensureMigrationTables(db)
+	err := m.ensureMigrationTables()
 	assert.Nil(t, err)
 
 	tables := []string{"migrations", "migration_lock"}
@@ -31,7 +32,7 @@ func TestEnsureMigrationTables(t *testing.T) {
 	assertOneLock(t, db)
 
 	// with existing tables, ensureMigrationTables should do anything
-	err = ensureMigrationTables(db)
+	err = m.ensureMigrationTables()
 	assert.Nil(t, err)
 
 	for _, table := range tables {
@@ -44,9 +45,13 @@ func TestEnsureMigrationTables(t *testing.T) {
 func dropMigrationTables(t *testing.T, db *pg.DB) {
 	t.Helper()
 
-	_, err := db.Exec("DROP TABLE migrations")
+	_, err := db.Exec("DROP TABLE IF EXISTS migrations")
 	assert.Nil(t, err)
-	_, err = db.Exec("DROP TABLE migration_lock")
+	_, err = db.Exec("DROP TABLE IF EXISTS migration_lock")
+	assert.Nil(t, err)
+	_, err = db.Exec("DROP TABLE IF EXISTS custom_migrations")
+	assert.Nil(t, err)
+	_, err = db.Exec("DROP TABLE IF EXISTS custom_migration_lock")
 	assert.Nil(t, err)
 }
 

--- a/status.go
+++ b/status.go
@@ -7,15 +7,9 @@ import (
 	"sort"
 	"strings"
 	"unicode/utf8"
-
-	"github.com/go-pg/pg/v10"
 )
 
-type migrationWithStatus struct {
-	migration
-}
-
-func status(db *pg.DB, w io.Writer) error {
+func (m *migrator) status(w io.Writer) error {
 	// sort the registered migrations by name (which will sort by the
 	// timestamp in their names)
 	sort.Slice(migrations, func(i, j int) bool {
@@ -23,7 +17,7 @@ func status(db *pg.DB, w io.Writer) error {
 	})
 
 	// look at the migrations table to see the already run migrations
-	completed, err := getCompletedMigrations(db)
+	completed, err := m.getCompletedMigrations()
 	if err != nil {
 		return err
 	}
@@ -35,7 +29,7 @@ func status(db *pg.DB, w io.Writer) error {
 	return writeStatusTable(w, completed, uncompleted)
 }
 
-func writeStatusTable(w io.Writer, completed []migration, uncompleted []migration) error {
+func writeStatusTable(w io.Writer, completed []*migration, uncompleted []*migration) error {
 	if len(completed)+len(uncompleted) == 0 {
 		_, err := fmt.Fprintln(w, "No migrations found")
 		return err
@@ -76,7 +70,6 @@ func writeStatusTable(w io.Writer, completed []migration, uncompleted []migratio
 func maxInt(a, b int) int {
 	if a > b {
 		return a
-	} else {
-		return b
 	}
+	return b
 }


### PR DESCRIPTION
### what

allow customizing the table names for `migrations` and `migration_lock`. this add the new function `RunWithOptions` so that it doesn't break people using `Run`